### PR TITLE
Fix/latest outscale provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository enable you to create a VPC and a set of resources in the Outscale Cloud from terraform files and a description and configuration yaml file
 
+Breaking Changes!:
+This module use v1.x version of outscale terraform provider
+You must migrate your state following this guide
+
+https://github.com/outscale/terraform-provider-outscale/blob/master/MIGRATION.md
+
 ## What does it do?
 
 You describe the topology in one Yaml configuration file (`config.yml`), then execute terraform, and the following resources are created:
@@ -236,6 +242,7 @@ default:
   load_balancers:
     lb01:
       load_balancer_type: internet-facing  # use 'internal' for internal LB
+      use_hashed_name: true  # generate a sha1 name of lb to stay within the Outscale limit of 32 characters
       public_ip: lb01
       subnets:
         - public-front-a

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -3,7 +3,13 @@
 #
 resource "outscale_load_balancer" "lb" {
   for_each           = local.resources.load_balancers
-  load_balancer_name = format("%s-%s", local.default.prefix_name, each.key)
+
+  load_balancer_name = (
+    lookup(each.value, "use_hashed_name", false)
+    ? substr(sha1(format("%s-%s", local.default.prefix_name, each.key)), 0, 32)
+    : format("%s-%s", local.default.prefix_name, each.key)
+  )
+
   load_balancer_type = each.value.load_balancer_type
 
   dynamic "listeners" {

--- a/modules/instance/vm/cloudinit.tf
+++ b/modules/instance/vm/cloudinit.tf
@@ -63,7 +63,7 @@ data "cloudinit_config" "vm_config" {
     content {
       filename     = part.value.filename
       content_type = part.value.content_type
-      content      = part.value.content
+      content      = sensitive(part.value.content)
     }
   }
 }

--- a/modules/instance/vm/main.tf
+++ b/modules/instance/vm/main.tf
@@ -99,7 +99,7 @@ resource "outscale_volume" "volume" {
   }
 }
 
-resource "outscale_volumes_link" "volumes_link" {
+resource "outscale_volume_link" "volumes_link" {
   for_each = { for k, v in local.volume_list : k => v if v.name != "root" && v.state != "detached" }
 
   device_name = each.value.device_name
@@ -125,7 +125,7 @@ resource "outscale_vm" "vm" {
 
   # placement_subregion_name = var.subregion_name
 
-  is_source_dest_checked = contains(keys(var.value), "is_source_dest_checked") ? var.value.is_source_dest_checked : true
+  is_source_dest_checked = contains(keys(var.value), "is_source_dest_checked") ? tobool(var.value.is_source_dest_checked) : true
 
   # link nics
   dynamic "nics" {
@@ -172,7 +172,7 @@ resource "outscale_vm" "vm" {
     }
   }
 
-  depends_on = [outscale_nic.nic]
+  # depends_on = [outscale_nic.nic]
   # don't force-recreate instance if only user data changes
   lifecycle {
     ignore_changes = [user_data]

--- a/modules/instance/vm/main.tf
+++ b/modules/instance/vm/main.tf
@@ -121,7 +121,7 @@ resource "outscale_vm" "vm" {
   keypair_name = var.config.default.keypair_name
   state        = local.state
 
-  user_data = local.enable_user_data ? local.user_data : null
+  user_data = sensitive(local.enable_user_data ? local.user_data : null)
 
   # placement_subregion_name = var.subregion_name
 
@@ -221,5 +221,6 @@ output "vm_id" {
 
 output "user_data" {
   value = local.user_data
+  sensitive = true
 }
 

--- a/modules/instance/vm/providers.tf
+++ b/modules/instance/vm/providers.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     outscale = {
       source  = "outscale/outscale"
-      version = "0.10.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     outscale = {
       source  = "outscale/outscale"
-      version = "0.10.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
- Add loadbalancer `use_hashed_name: true` :  optional key to generate an lb name to stay within the 32 character limit. See [load_balancer](https://registry.terraform.io/providers/outscale/outscale/latest/docs/resources/load_balancer#load_balancer_name-1)
- protect sensitive user_data

Breaking Changes ⚠️ 

- Use v1.x outscale terraform provider
- must migrate tf state
- seed this guide : https://github.com/outscale/terraform-provider-outscale/blob/master/MIGRATION.md